### PR TITLE
Add Generators for new components, types, and utils

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js -linguist-detectable
+*.ejs.t -linguist-detectable

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Run the following scripts with `npm run <SCRIPT_HERE>`:
 - `test:visual` - run visual tests with loki (this assumes that storybook is running)
 - `test:visual:approve` - approve visual changes
 - `test:visual:update` - update or create visual references
+- `new:component` - generate a new component
+- `new:util` - generate a new util
+- `new:type` - generate a new type
 
 > These scripts are located in `package.json` and do not represent the entirety of available scripts, but are the most commonly used.
 

--- a/_templates/component/new/README.ejs.t
+++ b/_templates/component/new/README.ejs.t
@@ -1,0 +1,23 @@
+---
+to: src/components/<%= name %>/README.md
+---
+# `<<%= name %> />`
+
+DESCRIPTION_HERE
+
+## Directory Structure
+
+- `stories.tsx`: Component playground (`npm run test:playground`)
+- `test.tsx`: Component tests (`npm run test:unit`)
+- `index.tsx`: Component code
+- `README.md`: Component documentation (hey, that's me!)
+
+## Example
+
+![<%= name %>](../../../.loki/reference/chrome_<%= name %>_example.png)
+
+> Image location: [`.loki/reference/chrome_<%= name %>_example.png`](../../../.loki/reference/chrome_<%= name %>_example.png)
+> 
+> To regenerate: 
+> 1. `npm run test:playground` (skip if running)
+> 1. `npm run test:visual:update -- --storiesFilter="^<%= name %> example\$"`

--- a/_templates/component/new/import.ejs.t
+++ b/_templates/component/new/import.ejs.t
@@ -1,0 +1,6 @@
+---
+inject: true
+to: ./src/stories/index.tsx
+append: true
+---
+import "../../src/components/<%= name %>/stories"

--- a/_templates/component/new/module.ejs.t
+++ b/_templates/component/new/module.ejs.t
@@ -1,0 +1,36 @@
+---
+to: src/components/<%= name %>/index.tsx
+---
+<% if(useState) { -%>
+import React, { useState } from "react"
+import { Button, StyleSheet, Text, View } from "react-native"
+
+type Props = Readonly<{}>
+
+export function <%= name %>(_: Props) {
+  const [count, setCount] = useState(0)
+  return (
+    <View style={styles.container}>
+      <Text>You clicked {count} times</Text>
+      <Button onPress={() => setCount(count + 1)} title="<%= name %>" />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {},
+})
+<% } else { -%>
+import React from "react"
+import { StyleSheet, Text } from "react-native"
+
+type Props = Readonly<{}>
+
+export function <%= name %>(_: Props) {
+  return <Text style={styles.container}><%= name %></Text>
+}
+
+const styles = StyleSheet.create({
+  container: {},
+})
+<% } -%>

--- a/_templates/component/new/module.ejs.t
+++ b/_templates/component/new/module.ejs.t
@@ -28,12 +28,16 @@ const styles = StyleSheet.create({
 })
 <% } else { -%>
 import React from "react"
-import { StyleSheet, Text } from "react-native"
+import { StyleSheet, Text, View } from "react-native"
 
 type Props = Readonly<{}>
 
 export function <%= name %>(_: Props) {
-  return <Text style={styles.container}><%= name %></Text>
+  return (
+    <View style={styles.container}>
+      <Text><%= name %></Text>
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({

--- a/_templates/component/new/module.ejs.t
+++ b/_templates/component/new/module.ejs.t
@@ -1,7 +1,13 @@
 ---
 to: src/components/<%= name %>/index.tsx
 ---
-<% if(useState) { -%>
+<% if(!withExample) { -%>
+import React from "react"
+
+export function <%= name %>() {
+  return <></>
+}
+<% } else if(useState) { -%>
 import React, { useState } from "react"
 import { Button, StyleSheet, Text, View } from "react-native"
 

--- a/_templates/component/new/prompt.js
+++ b/_templates/component/new/prompt.js
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const i = require("inflection")
+
+module.exports = {
+  prompt: ({ prompter }) => {
+    return prompter
+      .prompt({
+        type: "input",
+        name: "name",
+        message: "Component name:",
+      })
+      .then(({ name }) => {
+        return prompter
+          .prompt({
+            default: "N",
+            message: "Does component use state?",
+            name: "useState",
+            type: "toggle",
+          })
+          .then(({ useState }) => ({ name: i.camelize(name, false), useState }))
+      })
+  },
+}

--- a/_templates/component/new/prompt.js
+++ b/_templates/component/new/prompt.js
@@ -9,15 +9,38 @@ module.exports = {
         name: "name",
         message: "Component name:",
       })
-      .then(({ name }) => {
+      .then(({ name: nameRaw }) => {
+        const name = i.camelize(nameRaw || "Example", false)
+
         return prompter
           .prompt({
             default: "N",
-            message: "Does component use state?",
-            name: "useState",
+            message: `Did you want to generate <${name} /> with example code?`,
+            name: "withExample",
             type: "toggle",
           })
-          .then(({ useState }) => ({ name: i.camelize(name, false), useState }))
+          .then(({ withExample }) => {
+            if (withExample) {
+              return prompter
+                .prompt({
+                  default: "N",
+                  message: `Did you want to include useState in the example <${name} />?`,
+                  name: "useState",
+                  type: "toggle",
+                })
+                .then(({ useState }) => ({
+                  name,
+                  withExample,
+                  useState,
+                }))
+            }
+
+            return {
+              name,
+              withExample,
+              useState: false,
+            }
+          })
       })
   },
 }

--- a/_templates/component/new/stories.ejs.t
+++ b/_templates/component/new/stories.ejs.t
@@ -1,0 +1,8 @@
+---
+to: src/components/<%= name %>/stories.tsx
+---
+import { storiesOf } from "@storybook/react-native"
+import React from "react"
+import { <%= name %> } from "."
+
+storiesOf("<%= name %>", module).add("example", () => <<%= name %> />)

--- a/_templates/component/new/test.ejs.t
+++ b/_templates/component/new/test.ejs.t
@@ -1,7 +1,14 @@
 ---
 to: src/components/<%= name %>/test.tsx
 ---
-<% if(useState) { -%>
+<% if(!withExample) { -%>
+import { <%= name %> } from "."
+import React from "react"
+
+describe("<%= name %>", () => {
+  it.todo("...")
+})
+<% } else if(useState) { -%>
 import { <%= name %> } from "."
 import { render, fireEvent } from "@testing-library/react-native"
 import React from "react"

--- a/_templates/component/new/test.ejs.t
+++ b/_templates/component/new/test.ejs.t
@@ -1,0 +1,55 @@
+---
+to: src/components/<%= name %>/test.tsx
+---
+<% if(useState) { -%>
+import { <%= name %> } from "."
+import { render, fireEvent } from "@testing-library/react-native"
+import React from "react"
+
+describe("<%= name %>", () => {
+  it("has correct message before clicking", () => {
+    // Arrange
+    const message = "You clicked 0 times"
+
+    // Act
+    const { getByText } = render(<<%= name %> />)
+    const received = getByText(message)
+
+    // Assert
+    expect(received).toBeDefined()
+  })
+
+  it("has correct message after clicking", () => {
+    // Arrange
+    const name = "Click Me"
+    const message = "You clicked 1 times"
+
+    // Act
+    const { getByText } = render(<<%= name %> />)
+    const button = getByText(name)
+    fireEvent.press(button)
+    const received = getByText(message)
+
+    // Assert
+    expect(received).toBeDefined()
+  })
+})
+<% } else { -%>
+import { <%= name %> } from "."
+import { render } from "@testing-library/react-native"
+import React from "react"
+
+describe("<%= name %>", () => {
+  it("name prop is rendered", () => {
+    // Arrange
+    const name = "<%= name %>"
+
+    // Act
+    const { getByText } = render(<<%= name %> />)
+    const received = getByText(name)
+
+    // Assert
+    expect(received).toBeDefined()
+  })
+})
+<% } -%>

--- a/_templates/component/new/test.ejs.t
+++ b/_templates/component/new/test.ejs.t
@@ -6,7 +6,7 @@ import { <%= name %> } from "."
 import React from "react"
 
 describe("<%= name %>", () => {
-  it.todo("...")
+  it.todo(`<%= name %> needs to be tested`)
 })
 <% } else if(useState) { -%>
 import { <%= name %> } from "."

--- a/_templates/type/new/index.ejs.t
+++ b/_templates/type/new/index.ejs.t
@@ -1,0 +1,4 @@
+---
+to: src/types/<%= name %>.ts
+---
+export interface <%= name %> {}

--- a/_templates/type/new/prompt.js
+++ b/_templates/type/new/prompt.js
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const i = require("inflection")
+
+module.exports = {
+  prompt: ({ prompter }) => {
+    return prompter
+      .prompt({
+        type: "input",
+        name: "name",
+        message: "What's the name of the type?",
+      })
+      .then(({ name }) => ({
+        name: i.camelize(name, false),
+      }))
+  },
+}

--- a/_templates/util/new/README.ejs.t
+++ b/_templates/util/new/README.ejs.t
@@ -1,0 +1,14 @@
+---
+to: src/utils/<%= name %>/README.md
+---
+# `<%= name %>`
+
+DESCRIPTION_HERE
+
+## Example
+
+```ts
+import { <%= name %> } from "./<%= name %>"
+
+<%= name %>(1) // 1
+```

--- a/_templates/util/new/module.ejs.t
+++ b/_templates/util/new/module.ejs.t
@@ -1,0 +1,4 @@
+---
+to: src/utils/<%= name %>/index.ts
+---
+export const <%= name %> = <A>(x: A) => x

--- a/_templates/util/new/prompt.js
+++ b/_templates/util/new/prompt.js
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const i = require("inflection")
+
+module.exports = {
+  prompt: ({ prompter }) => {
+    return prompter
+      .prompt({
+        type: "input",
+        name: "name",
+        message: "What's the name of the utility?",
+      })
+      .then(({ name }) => ({
+        name: i.camelize(name, true),
+      }))
+  },
+}

--- a/_templates/util/new/test.ejs.t
+++ b/_templates/util/new/test.ejs.t
@@ -1,0 +1,18 @@
+---
+to: src/utils/<%= name %>/test.ts
+---
+import { <%= name %> } from "."
+
+describe("<%= name %>", () => {
+  it("works", () => {
+    // Arrange
+    const valA = 1
+
+    // Act
+    const received = <%= name %>(valA)
+    const expected = 1
+
+    // Assert
+    expect(received).toEqual(expected)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -7396,6 +7396,15 @@
         "node-releases": "^1.1.46"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -7626,6 +7635,53 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
+      },
+      "dependencies": {
+        "dot-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+          "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "pascal-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+          "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "upper-case-first": "^1.1.0"
+          }
+        }
       }
     },
     "character-entities": {
@@ -8271,6 +8327,16 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
+    },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "dev": true,
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -9433,6 +9499,23 @@
             "errno": "^0.1.3",
             "readable-stream": "^2.0.1"
           }
+        }
+      }
+    },
+    "enquirer": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
+      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+          "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
         }
       }
     },
@@ -11103,6 +11186,15 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "front-matter": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
+      "integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.10.0"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -12115,6 +12207,16 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
     "hermes-engine": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.2.1.tgz",
@@ -12599,6 +12701,37 @@
       "integrity": "sha512-gc1TzCc2jLuI+BFddYBJf9LGal4dTCUvnRKL6ylYhiBsEg2+5Mp00+tikoF9t8xqKLq3E1EoHf/sV/lIrxLErw==",
       "dev": true
     },
+    "hygen": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hygen/-/hygen-5.0.3.tgz",
+      "integrity": "sha512-tepicT366of7FZKfuT/YtTOZ1mU7txQix2EgYEGOCBD4SN3+vf2tRITB/yA7Amd9NPhzijgCYkW/MlIsdXEEEQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "change-case": "^3.1.0",
+        "ejs": "^2.6.1",
+        "enquirer": "^2.3.0",
+        "execa": "^1.0.0",
+        "front-matter": "^2.3.0",
+        "fs-extra": "^7.0.1",
+        "ignore-walk": "^3.0.2",
+        "inflection": "^1.12.0",
+        "ts-jest": "^24.1.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "hyphenate-style-name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
@@ -12644,6 +12777,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "iltorb": {
       "version": "2.4.5",
@@ -12747,6 +12889,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true
+    },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
       "dev": true
     },
     "inflight": {
@@ -13302,6 +13450,15 @@
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
@@ -13441,6 +13598,15 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -15264,6 +15430,15 @@
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.2"
+      }
+    },
     "lowlight": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
@@ -15291,6 +15466,12 @@
         "pify": "^4.0.1",
         "semver": "^5.6.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -17010,6 +17191,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
       "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -19706,6 +19896,16 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
     "serialize-error": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
@@ -19985,6 +20185,15 @@
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
       "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ==",
       "dev": true
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -20688,6 +20897,16 @@
         }
       }
     },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -21170,6 +21389,16 @@
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
       "dev": true
     },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -21441,6 +21670,50 @@
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
       "integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
+      "integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "0.x",
+        "resolve": "1.x",
+        "semver": "^5.5",
+        "yargs-parser": "10.x"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "ts-pnp": {
       "version": "1.1.5",
@@ -21758,6 +22031,15 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "test:visual:update": "loki update",
     "test:visual:approve": "loki approve",
     "test:expo": "expo doctor && ./test-expo-start.sh && ./test-expo-watch-mode.sh",
+    "new:component": "hygen component new",
+    "new:type": "hygen type new",
+    "new:util": "hygen util new",
     "prepush": "npm run test:ci",
     "postinstall": "patch-package"
   },
@@ -71,6 +74,7 @@
     "eslint-plugin-react-native": "^3.8.1",
     "husky": "^4.2.3",
     "husky-add-issue-tracker": "0.0.9",
+    "hygen": "^5.0.3",
     "jest-expo": "^36.0.1",
     "loki": "^0.20.1",
     "npm-run-all": "^4.1.5",

--- a/src/components/App/README.md
+++ b/src/components/App/README.md
@@ -1,0 +1,20 @@
+# `<App />`
+
+The root component that contains the entire tree of components.
+
+## Directory Structure
+
+- `stories.tsx`: Component playground (`npm run test:playground`)
+- `test.tsx`: Component tests (`npm run test:unit`)
+- `index.tsx`: Component code
+- `README.md`: Component documentation (hey, that's me!)
+
+## Example
+
+![App](../../../.loki/reference/chrome_App_example.png)
+
+> Image location: [`.loki/reference/chrome_App_example.png`](../../../.loki/reference/chrome_App_example.png)
+> 
+> To regenerate: 
+> 1. `npm run test:playground` (skip if running)
+> 1. `npm run test:visual:update -- --storiesFilter="^App example\$"`

--- a/src/components/App/stories.tsx
+++ b/src/components/App/stories.tsx
@@ -2,4 +2,9 @@ import { storiesOf } from "@storybook/react-native"
 import React from "react"
 import { App } from "."
 
-storiesOf("App", module).add("default", () => <App />)
+/**
+ * See Storybook Docs: Writing Stories
+ * https://storybook.js.org/docs/basics/writing-stories/
+ */
+
+storiesOf("App", module).add("example", () => <App />)

--- a/src/components/App/stories.tsx
+++ b/src/components/App/stories.tsx
@@ -2,9 +2,4 @@ import { storiesOf } from "@storybook/react-native"
 import React from "react"
 import { App } from "."
 
-/**
- * See Storybook Docs: Writing Stories
- * https://storybook.js.org/docs/basics/writing-stories/
- */
-
 storiesOf("App", module).add("example", () => <App />)

--- a/src/components/App/test.tsx
+++ b/src/components/App/test.tsx
@@ -4,11 +4,16 @@ import { App } from "."
 
 describe("App", () => {
   it("renders", async () => {
+    // Arrange
+    const title = "Welcome to crema-app-mobile"
+    const subtitle = "Open up App.tsx to start working on your app!"
+
+    // Act
     const { getByText, queryByText } = render(<App />)
+    await waitForElement(() => queryByText(title))
+    const received = getByText(subtitle)
 
-    await waitForElement(() => queryByText("Welcome to crema-app-mobile"))
-    const text = getByText("Open up App.tsx to start working on your app!")
-
-    expect(text).toBeDefined()
+    // Assert
+    expect(received).toBeDefined()
   })
 })

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -1,0 +1,20 @@
+# `<Container />`
+
+The `Container` component should wrap the rest of the application to provide `AppLoading` as well as `SafeAreaView`.
+
+## Directory Structure
+
+- `stories.tsx`: Component playground (`npm run test:playground`)
+- `test.tsx`: Component tests (`npm run test:unit`)
+- `index.tsx`: Component code
+- `README.md`: Component documentation (hey, that's me!)
+
+## Example
+
+![Container](../../../.loki/reference/chrome_Container_example.png)
+
+> Image location: [`.loki/reference/chrome_Container_example.png`](../../../.loki/reference/chrome_Container_example.png)
+> 
+> To regenerate: 
+> 1. `npm run test:playground` (skip if running)
+> 1. `npm run test:visual:update -- --storiesFilter="^Container example\$"`

--- a/src/components/Container/stories.tsx
+++ b/src/components/Container/stories.tsx
@@ -3,7 +3,12 @@ import React from "react"
 import { Text } from "react-native"
 import { Container } from "."
 
-storiesOf("Container", module).add("default", () => (
+/**
+ * See Storybook Docs: Writing Stories
+ * https://storybook.js.org/docs/basics/writing-stories/
+ */
+
+storiesOf("Container", module).add("example", () => (
   <Container>
     <Text>Test</Text>
   </Container>

--- a/src/components/Container/stories.tsx
+++ b/src/components/Container/stories.tsx
@@ -3,11 +3,6 @@ import React from "react"
 import { Text } from "react-native"
 import { Container } from "."
 
-/**
- * See Storybook Docs: Writing Stories
- * https://storybook.js.org/docs/basics/writing-stories/
- */
-
 storiesOf("Container", module).add("example", () => (
   <Container>
     <Text>Test</Text>

--- a/src/components/Container/test.tsx
+++ b/src/components/Container/test.tsx
@@ -5,15 +5,19 @@ import { Container } from "."
 
 describe("Container", () => {
   it("renders", async () => {
+    // Arrange
+    const text = "Test"
+
+    // Act
     const { getByText, queryByText } = render(
       <Container>
-        <Text>Test</Text>
+        <Text>{text}</Text>
       </Container>,
     )
+    await waitForElement(() => queryByText(text))
+    const received = getByText(text)
 
-    await waitForElement(() => queryByText("Test"))
-    const text = getByText("Test")
-
-    expect(text).toBeDefined()
+    // Assert
+    expect(received).toBeDefined()
   })
 })

--- a/src/components/Counter/README.md
+++ b/src/components/Counter/README.md
@@ -1,0 +1,20 @@
+# `<Counter />`
+
+An example `Counter` component that can increment or decrement a count that is displayed on screen.
+
+## Directory Structure
+
+- `stories.tsx`: Component playground (`npm run test:playground`)
+- `test.tsx`: Component tests (`npm run test:unit`)
+- `index.tsx`: Component code
+- `README.md`: Component documentation (hey, that's me!)
+
+## Example
+
+![Counter](../../../.loki/reference/chrome_Counter_example.png)
+
+> Image location: [`.loki/reference/chrome_Counter_example.png`](../../../.loki/reference/chrome_Counter_example.png)
+> 
+> To regenerate: 
+> 1. `npm run test:playground` (skip if running)
+> 1. `npm run test:visual:update -- --storiesFilter="^Counter example\$"`

--- a/src/components/Counter/stories.tsx
+++ b/src/components/Counter/stories.tsx
@@ -2,9 +2,4 @@ import { storiesOf } from "@storybook/react-native"
 import React from "react"
 import { Counter } from "."
 
-/**
- * See Storybook Docs: Writing Stories
- * https://storybook.js.org/docs/basics/writing-stories/
- */
-
 storiesOf("Counter", module).add("example", () => <Counter />)

--- a/src/components/Counter/stories.tsx
+++ b/src/components/Counter/stories.tsx
@@ -2,4 +2,9 @@ import { storiesOf } from "@storybook/react-native"
 import React from "react"
 import { Counter } from "."
 
-storiesOf("Counter", module).add("default", () => <Counter />)
+/**
+ * See Storybook Docs: Writing Stories
+ * https://storybook.js.org/docs/basics/writing-stories/
+ */
+
+storiesOf("Counter", module).add("example", () => <Counter />)

--- a/src/components/Counter/test.tsx
+++ b/src/components/Counter/test.tsx
@@ -4,24 +4,44 @@ import { Counter } from "."
 
 describe("Counter", () => {
   it("displays the initial count", () => {
+    // Arrange
+    const text = "Count is: 0"
+
+    // Act
     const { getByText } = render(<Counter />)
-    const text = getByText("Count is: 0")
-    expect(text).toBeDefined()
+    const received = getByText(text)
+
+    // Assert
+    expect(received).toBeDefined()
   })
 
   it("can decrement count", () => {
+    // Arrange
+    const text = "Count is: -1"
+    const buttonText = "-"
+
+    // Act
     const { getByText } = render(<Counter />)
-    const button = getByText("-")
+    const button = getByText(buttonText)
     fireEvent.press(button)
-    const text = getByText("Count is: -1")
-    expect(text).toBeDefined()
+    const received = getByText(text)
+
+    // Assert
+    expect(received).toBeDefined()
   })
 
   it("can increment count", () => {
+    // Arrange
+    const text = "Count is: 1"
+    const buttonText = "+"
+
+    // Act
     const { getByText } = render(<Counter />)
-    const button = getByText("+")
+    const button = getByText(buttonText)
     fireEvent.press(button)
-    const text = getByText("Count is: 1")
-    expect(text).toBeDefined()
+    const received = getByText(text)
+
+    // Assert
+    expect(received).toBeDefined()
   })
 })


### PR DESCRIPTION
## Description

Adds hygen generators for `component`, `util`, and `type`. The component generator can create a bare-bones component or an example component with `useState`.

Closes #4 

### 👩‍🔬 Test Instructions

1. pull down PR
1. run `npm ci`
1. run `npm run new:component` 
1. run `npm run new:util`
1. run `npm run new:type`

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

### Additional

> Delete if unneeded

- [ ] Code has been tested and confirmed locally

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup