### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,22 +20,6 @@
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
-    },
-    {
-      "packageNames": [
-        "expo",
-        "react",
-        "react-dom",
-        "react-native",
-        "react-native-screens",
-        "react-native-web",
-        "@types/react",
-        "@types/react-native",
-        "jest-expo"
-      ],
-      "automerge": false,
-      "enabled": true,
-      "groupName": "expo"
     }
   ]
 }


### PR DESCRIPTION
## Description

Removed the `expo` group I created in the renovate config since it wasn't helping at all, the packages while tangentially related can't always be updated in sync. 🤷‍♀️

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [x] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup