### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,11 +11,7 @@
   "packageRules": [
     {
       "updateTypes": ["major"],
-      "automerge": false,
-      "reviewers": [
-        "roblafeve",
-        "blaketarter"
-      ]
+      "automerge": false
     },
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Description

Remove the auto-tagging of reviewers.


## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup