### PR TITLE
Add npmrc to change npm to legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6135,6 +6135,57 @@
         "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
       }
     },
+    "node_modules/@react-native-community/cli": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.14.0.tgz",
+      "integrity": "sha512-EYJKBuxFxAu/iwNUfwDq41FjORpvSh1wvQ3qsHjzcR5uaGlWEOJrd3uNJDuKBAS0TVvbEesLF9NEXipjyRVr4Q==",
+      "dependencies": {
+        "@hapi/joi": "^15.0.3",
+        "@react-native-community/cli-debugger-ui": "^4.13.1",
+        "@react-native-community/cli-hermes": "^4.13.0",
+        "@react-native-community/cli-server-api": "^4.13.1",
+        "@react-native-community/cli-tools": "^4.13.0",
+        "@react-native-community/cli-types": "^4.10.1",
+        "chalk": "^3.0.0",
+        "command-exists": "^1.2.8",
+        "commander": "^2.19.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.3",
+        "inquirer": "^3.0.6",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "metro": "^0.59.0",
+        "metro-config": "^0.59.0",
+        "metro-core": "^0.59.0",
+        "metro-react-native-babel-transformer": "^0.59.0",
+        "metro-resolver": "^0.59.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^3.4.0",
+        "pretty-format": "^25.2.0",
+        "semver": "^6.3.0",
+        "serve-static": "^1.13.1",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "bin": {
+        "react-native": "build/bin.js"
+      },
+      "engines": {
+        "node": ">=8.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.62.0-rc.0 <0.64.0"
+      }
+    },
     "node_modules/@react-native-community/cli-debugger-ui": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz",
@@ -6587,6 +6638,207 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-4.10.1.tgz",
       "integrity": "sha512-ael2f1onoPF3vF7YqHGWy7NnafzGu+yp88BbFbP0ydoCP2xGSUzmZVw0zakPTC040Id+JQ9WeFczujMkDy6jYQ=="
+    },
+    "node_modules/@react-native-community/cli/node_modules/@jest/types": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@react-native-community/cli/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/@react-native-community/cli/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/pretty-format": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+      "dependencies": {
+        "@jest/types": "^25.5.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      },
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/@react-native-community/cli/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.1",
@@ -16093,18 +16345,18 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
@@ -16275,7 +16527,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
       "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-      "dev": true,
       "dependencies": {
         "stackframe": "^1.1.1"
       }
@@ -20578,9 +20829,9 @@
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "node_modules/immer": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
-      "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -29299,9 +29550,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.58.0.tgz",
-      "integrity": "sha512-yi/REXX+/s4r7RjzXht+E+qE6nzvFIrEXO5Q61h+70Q7RODMU8EnlpXx04JYk7DevHuMhFaX+NWhCtRINzR4zA==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.59.0.tgz",
+      "integrity": "sha512-OpVgYXyuTvouusFZQJ/UYKEbwfLmialrSCUUTGTFaBor6UMUHZgXPYtK86LzesgMqRc8aiuTQVO78iKW2Iz3wg==",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -29321,28 +29572,29 @@
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
+        "error-stack-parser": "^2.0.6",
         "eventemitter3": "^3.0.0",
         "fbjs": "^1.0.0",
         "fs-extra": "^1.0.0",
         "graceful-fs": "^4.1.3",
         "image-size": "^0.6.0",
         "invariant": "^2.2.4",
-        "jest-haste-map": "^24.7.1",
-        "jest-worker": "^24.6.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-worker": "^24.9.0",
         "json-stable-stringify": "^1.0.1",
         "lodash.throttle": "^4.1.1",
         "merge-stream": "^1.0.1",
-        "metro-babel-register": "0.58.0",
-        "metro-babel-transformer": "0.58.0",
-        "metro-cache": "0.58.0",
-        "metro-config": "0.58.0",
-        "metro-core": "0.58.0",
-        "metro-inspector-proxy": "0.58.0",
-        "metro-minify-uglify": "0.58.0",
-        "metro-react-native-babel-preset": "0.58.0",
-        "metro-resolver": "0.58.0",
-        "metro-source-map": "0.58.0",
-        "metro-symbolicate": "0.58.0",
+        "metro-babel-register": "0.59.0",
+        "metro-babel-transformer": "0.59.0",
+        "metro-cache": "0.59.0",
+        "metro-config": "0.59.0",
+        "metro-core": "0.59.0",
+        "metro-inspector-proxy": "0.59.0",
+        "metro-minify-uglify": "0.59.0",
+        "metro-react-native-babel-preset": "0.59.0",
+        "metro-resolver": "0.59.0",
+        "metro-source-map": "0.59.0",
+        "metro-symbolicate": "0.59.0",
         "mime-types": "2.1.11",
         "mkdirp": "^0.5.1",
         "node-fetch": "^2.2.0",
@@ -29355,7 +29607,6 @@
         "temp": "0.8.3",
         "throat": "^4.1.0",
         "wordwrap": "^1.0.0",
-        "write-file-atomic": "^1.2.0",
         "ws": "^1.1.5",
         "xpipe": "^1.0.5",
         "yargs": "^14.2.0"
@@ -29380,120 +29631,55 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.58.0.tgz",
-      "integrity": "sha512-yBX3BkRhw2TCNPhe+pmLSgsAEA3huMvnX08UwjFqSXXI1aiqzRQobn92uKd1U5MM1Vx8EtXVomlJb95ZHNAv6A==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.59.0.tgz",
+      "integrity": "sha512-fdZJl8rs54GVFXokxRdD7ZrQ1TJjxWzOi/xSP25VR3E8tbm3nBZqS+/ylu643qSr/IueABR+jrlqAyACwGEf6w==",
       "dependencies": {
         "@babel/core": "^7.0.0",
-        "metro-source-map": "0.58.0"
-      }
-    },
-    "node_modules/metro-babel-transformer/node_modules/metro-source-map": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-      "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-      "dependencies": {
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.58.0",
-        "ob1": "0.58.0",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
+        "metro-source-map": "0.59.0"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.58.0.tgz",
-      "integrity": "sha512-jjW9zCTKxhgKcVkyQ6LHyna9Zdf4TK/45vvT1fPyyTk1RY82ZYjU1qs+84ycKEd08Ka4YcK9xcUew9SIDJYI8Q==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.59.0.tgz",
+      "integrity": "sha512-ryWNkSnpyADfRpHGb8BRhQ3+k8bdT/bsxMH2O0ntlZYZ188d8nnYWmxbRvFmEzToJxe/ol4uDw0tJFAaQsN8KA==",
       "dependencies": {
-        "jest-serializer": "^24.4.0",
-        "metro-core": "0.58.0",
+        "jest-serializer": "^24.9.0",
+        "metro-core": "0.59.0",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.58.0.tgz",
-      "integrity": "sha512-4vgBliXwL56vjUlYplvGMVSNrJJpkHuLcD+O20trV3FvPxKg4ZsvuOcNSxqDSMU26FCtIEJ15ojcuCbRL7KY0w==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.59.0.tgz",
+      "integrity": "sha512-MDsknFG9vZ4Nb5VR6OUDmGHaWz6oZg/FtE3up1zVBKPVRTXE1Z+k7zypnPtMXjMh3WHs/Sy4+wU1xnceE/zdnA==",
       "dependencies": {
         "cosmiconfig": "^5.0.5",
-        "jest-validate": "^24.7.0",
-        "metro": "0.58.0",
-        "metro-cache": "0.58.0",
-        "metro-core": "0.58.0",
-        "pretty-format": "^24.7.0"
+        "jest-validate": "^24.9.0",
+        "metro": "0.59.0",
+        "metro-cache": "0.59.0",
+        "metro-core": "0.59.0"
       }
-    },
-    "node_modules/metro-config/node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/metro-config/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/metro-config/node_modules/@types/yargs": {
-      "version": "13.0.11",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-      "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/metro-config/node_modules/pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/metro-config/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/metro-core": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.58.0.tgz",
-      "integrity": "sha512-RzXUjGFmCLOyzUqcKDvr91AldGtIOxnzNZrWUIiG8uC3kerVLo0mQp4YH3+XVm6fMNiLMg6iER7HLqD+MbpUjQ==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.59.0.tgz",
+      "integrity": "sha512-kb5LKvV5r2pqMEzGyTid8ai2mIjW13NMduQ8oBmfha7/EPTATcTQ//s+bkhAs1toQD8vqVvjAb0cPNjWQEmcmQ==",
       "dependencies": {
-        "jest-haste-map": "^24.7.1",
+        "jest-haste-map": "^24.9.0",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.58.0",
+        "metro-resolver": "0.59.0",
         "wordwrap": "^1.0.0"
       }
     },
     "node_modules/metro-inspector-proxy": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.58.0.tgz",
-      "integrity": "sha512-oFqTyNTJdCdvcw1Ha6SKE7ITbSaoTbO4xpYownIoJR+WZ0ZfxbWpp225JkHuBJm9UcBAnG9c0CME924m3uBbaw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.59.0.tgz",
+      "integrity": "sha512-hPeAuQcofTOH0F+2GEZqWkvkVY1/skezSSlMocDQDaqds+Kw6JgdA7FlZXxnKmQ/jYrWUzff/pl8SUCDwuYthQ==",
       "dependencies": {
         "connect": "^3.6.5",
         "debug": "^2.2.0",
-        "rxjs": "^5.4.3",
         "ws": "^1.1.5",
         "yargs": "^14.2.0"
       },
@@ -29639,9 +29825,9 @@
       }
     },
     "node_modules/metro-minify-uglify": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.58.0.tgz",
-      "integrity": "sha512-vRHsA7bCi7eCn3LXLm20EfY2NoWDyYOnmWaq/N8LB0OxL2L5DXRqMYAQK+prWGJ5S1yvVnDuuNVP+peQ9851TA==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.59.0.tgz",
+      "integrity": "sha512-7IzVgCVWZMymgZ/quieg/9v5EQ8QmZWAgDc86Zp9j0Vy6tQTjUn6jlU+YAKW3mfMEjMr6iIUzCD8YklX78tFAw==",
       "dependencies": {
         "uglify-es": "^3.1.9"
       }
@@ -29709,19 +29895,10 @@
         "@babel/core": "*"
       }
     },
-    "node_modules/metro-react-native-babel-transformer/node_modules/metro-babel-transformer": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.59.0.tgz",
-      "integrity": "sha512-fdZJl8rs54GVFXokxRdD7ZrQ1TJjxWzOi/xSP25VR3E8tbm3nBZqS+/ylu643qSr/IueABR+jrlqAyACwGEf6w==",
-      "dependencies": {
-        "@babel/core": "^7.0.0",
-        "metro-source-map": "0.59.0"
-      }
-    },
     "node_modules/metro-resolver": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.58.0.tgz",
-      "integrity": "sha512-XFbAKvCHN2iWqKeiRARzEXn69eTDdJVJC7lu16S4dPQJ+Dy82dZBr5Es12iN+NmbJuFgrAuIHbpWrdnA9tOf6Q==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.59.0.tgz",
+      "integrity": "sha512-lbgiumnwoVosffEI96z0FGuq1ejTorHAj3QYUPmp5dFMfitRxLP7Wm/WP9l4ZZjIptxTExsJwuEff1SLRCPD9w==",
       "dependencies": {
         "absolute-path": "^0.0.0"
       }
@@ -29740,7 +29917,12 @@
         "vlq": "^1.0.0"
       }
     },
-    "node_modules/metro-source-map/node_modules/metro-symbolicate": {
+    "node_modules/metro-source-map/node_modules/ob1": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.59.0.tgz",
+      "integrity": "sha512-opXMTxyWJ9m68ZglCxwo0OPRESIC/iGmKFPXEXzMZqsVIrgoRXOHmoMDkQzz4y3irVjbyPJRAh5pI9fd0MJTFQ=="
+    },
+    "node_modules/metro-symbolicate": {
       "version": "0.59.0",
       "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.59.0.tgz",
       "integrity": "sha512-asLaF2A7rndrToGFIknL13aiohwPJ95RKHf0NM3hP/nipiLDoMzXT6ZnQvBqDxkUKyP+51AI75DMtb+Wcyw4Bw==",
@@ -29756,43 +29938,6 @@
       },
       "engines": {
         "node": ">=8.3"
-      }
-    },
-    "node_modules/metro-source-map/node_modules/ob1": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.59.0.tgz",
-      "integrity": "sha512-opXMTxyWJ9m68ZglCxwo0OPRESIC/iGmKFPXEXzMZqsVIrgoRXOHmoMDkQzz4y3irVjbyPJRAh5pI9fd0MJTFQ=="
-    },
-    "node_modules/metro-symbolicate": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.58.0.tgz",
-      "integrity": "sha512-uIVxUQC1E26qOMj13dKROhwAa2FmZk5eR0NcBqej/aXmQhpr8LjJg2sondkoLKUp827Tf/Fm9+pS4icb5XiqCw==",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.58.0",
-        "source-map": "^0.5.6",
-        "through2": "^2.0.1",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/symbolicate.js"
-      },
-      "engines": {
-        "node": ">=8.3"
-      }
-    },
-    "node_modules/metro-symbolicate/node_modules/metro-source-map": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-      "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-      "dependencies": {
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.58.0",
-        "ob1": "0.58.0",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
       }
     },
     "node_modules/metro/node_modules/ansi-regex": {
@@ -29831,13 +29976,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/metro/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.",
-      "hasInstallScript": true
     },
     "node_modules/metro/node_modules/debug": {
       "version": "2.6.9",
@@ -29891,84 +30029,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/metro/node_modules/metro-babel-register": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.58.0.tgz",
-      "integrity": "sha512-P5+G3ufhSYL6cA3a7xkbSJzzFBvtivj/PhWvGXFXnuFssDlMAX1CTktff+0gpka5Cd6B6QLt0UAMWulUAAE4Eg==",
-      "dependencies": {
-        "@babel/core": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/register": "^7.0.0",
-        "core-js": "^2.2.2",
-        "escape-string-regexp": "^1.0.5"
-      }
-    },
-    "node_modules/metro/node_modules/metro-react-native-babel-preset": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
-      "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
-      "dependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.2.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-object-assign": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/metro/node_modules/metro-source-map": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-      "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-      "dependencies": {
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.58.0",
-        "ob1": "0.58.0",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
       }
     },
     "node_modules/metro/node_modules/mime-db": {
@@ -30101,16 +30161,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/metro/node_modules/write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
       }
     },
     "node_modules/metro/node_modules/yargs": {
@@ -30924,11 +30974,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/ob1": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.58.0.tgz",
-      "integrity": "sha512-uZP44cbowAfHafP1k4skpWItk5iHCoRevMfrnUvYCfyNNPPJd3rfDCyj0exklWi2gDXvjlj2ObsfiqP/bs/J7Q=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -31939,16 +31984,24 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "dependencies": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "xmldom": "^0.5.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/plist/node_modules/xmldom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/plugin-error": {
@@ -33296,9 +33349,9 @@
       }
     },
     "node_modules/react-dev-utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.1.tgz",
-      "integrity": "sha512-rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
+      "integrity": "sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.10.4",
@@ -33314,13 +33367,13 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "7.0.9",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "^6.0.8",
+        "react-error-overlay": "^6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
@@ -33665,9 +33718,9 @@
       }
     },
     "node_modules/react-error-overlay": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
-      "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "node_modules/react-fast-compare": {
@@ -33849,114 +33902,6 @@
         "ua-parser-js": "^0.7.18"
       }
     },
-    "node_modules/react-native/node_modules/@jest/types": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/react-native/node_modules/@react-native-community/cli": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.13.1.tgz",
-      "integrity": "sha512-+/TeRVToADpQPSprsPkwi9KY8x64YcuJpjzMBVISwWP+aWzsIDuWJmyMXTADlCg2EBMJqJR7bn1W/IkfzVRCWA==",
-      "dependencies": {
-        "@hapi/joi": "^15.0.3",
-        "@react-native-community/cli-debugger-ui": "^4.13.1",
-        "@react-native-community/cli-hermes": "^4.13.0",
-        "@react-native-community/cli-server-api": "^4.13.1",
-        "@react-native-community/cli-tools": "^4.13.0",
-        "@react-native-community/cli-types": "^4.10.1",
-        "chalk": "^3.0.0",
-        "command-exists": "^1.2.8",
-        "commander": "^2.19.0",
-        "cosmiconfig": "^5.1.0",
-        "deepmerge": "^3.2.0",
-        "envinfo": "^7.7.2",
-        "execa": "^1.0.0",
-        "find-up": "^4.1.0",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.3",
-        "inquirer": "^3.0.6",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.15",
-        "metro": "^0.58.0",
-        "metro-config": "^0.58.0",
-        "metro-core": "^0.58.0",
-        "metro-react-native-babel-transformer": "^0.58.0",
-        "metro-resolver": "^0.58.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-stream-zip": "^1.9.1",
-        "ora": "^3.4.0",
-        "pretty-format": "^25.2.0",
-        "semver": "^6.3.0",
-        "serve-static": "^1.13.1",
-        "strip-ansi": "^5.2.0",
-        "sudo-prompt": "^9.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "bin": {
-        "react-native": "build/bin.js"
-      },
-      "engines": {
-        "node": ">=8.3"
-      },
-      "peerDependencies": {
-        "react-native": ">=0.62.0-rc.0 <0.64.0"
-      }
-    },
-    "node_modules/react-native/node_modules/@react-native-community/cli/node_modules/metro-react-native-babel-transformer": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz",
-      "integrity": "sha512-3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==",
-      "dependencies": {
-        "@babel/core": "^7.0.0",
-        "babel-preset-fbjs": "^3.3.0",
-        "metro-babel-transformer": "0.58.0",
-        "metro-react-native-babel-preset": "0.58.0",
-        "metro-source-map": "0.58.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/react-native/node_modules/@react-native-community/cli/node_modules/metro-source-map": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-      "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-      "dependencies": {
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.58.0",
-        "ob1": "0.58.0",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/@react-native-community/cli/node_modules/pretty-format": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-      "dependencies": {
-        "@jest/types": "^25.5.0",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^16.12.0"
-      },
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
     "node_modules/react-native/node_modules/@types/istanbul-reports": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
@@ -33964,191 +33909,6 @@
       "dependencies": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/react-native/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/react-native/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/react-native/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/react-native/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/react-native/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-react-native-babel-preset": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
-      "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
-      "dependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.2.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-object-assign": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/react-native/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-native/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/react-native/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/react-native/node_modules/pretty-format": {
@@ -34230,25 +33990,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-native/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/react-native/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/react-popper": {
       "version": "1.3.7",
@@ -35132,17 +34873,6 @@
         "rx-lite": "*"
       }
     },
-    "node_modules/rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dependencies": {
-        "symbol-observable": "1.0.1"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -35600,14 +35330,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/slugify": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.0.tgz",
@@ -35953,8 +35675,7 @@
     "node_modules/stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-      "dev": true
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.10",
@@ -36482,14 +36203,6 @@
       "dependencies": {
         "lower-case": "^1.1.1",
         "upper-case": "^1.1.1"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -37611,6 +37324,7 @@
       "version": "3.3.9",
       "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
       "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
       "dependencies": {
         "commander": "~2.13.0",
         "source-map": "~0.6.1"
@@ -44324,6 +44038,197 @@
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "@react-native-community/cli": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.14.0.tgz",
+      "integrity": "sha512-EYJKBuxFxAu/iwNUfwDq41FjORpvSh1wvQ3qsHjzcR5uaGlWEOJrd3uNJDuKBAS0TVvbEesLF9NEXipjyRVr4Q==",
+      "requires": {
+        "@hapi/joi": "^15.0.3",
+        "@react-native-community/cli-debugger-ui": "^4.13.1",
+        "@react-native-community/cli-hermes": "^4.13.0",
+        "@react-native-community/cli-server-api": "^4.13.1",
+        "@react-native-community/cli-tools": "^4.13.0",
+        "@react-native-community/cli-types": "^4.10.1",
+        "chalk": "^3.0.0",
+        "command-exists": "^1.2.8",
+        "commander": "^2.19.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.3",
+        "inquirer": "^3.0.6",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "metro": "^0.59.0",
+        "metro-config": "^0.59.0",
+        "metro-core": "^0.59.0",
+        "metro-react-native-babel-transformer": "^0.59.0",
+        "metro-resolver": "^0.59.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^3.4.0",
+        "pretty-format": "^25.2.0",
+        "semver": "^6.3.0",
+        "serve-static": "^1.13.1",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@react-native-community/cli-debugger-ui": {
@@ -52452,18 +52357,18 @@
       }
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -52602,7 +52507,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
       "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-      "dev": true,
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -55952,9 +55856,9 @@
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "immer": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
-      "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
       "dev": true
     },
     "import-cwd": {
@@ -62655,9 +62559,9 @@
       "dev": true
     },
     "metro": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.58.0.tgz",
-      "integrity": "sha512-yi/REXX+/s4r7RjzXht+E+qE6nzvFIrEXO5Q61h+70Q7RODMU8EnlpXx04JYk7DevHuMhFaX+NWhCtRINzR4zA==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.59.0.tgz",
+      "integrity": "sha512-OpVgYXyuTvouusFZQJ/UYKEbwfLmialrSCUUTGTFaBor6UMUHZgXPYtK86LzesgMqRc8aiuTQVO78iKW2Iz3wg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -62677,28 +62581,29 @@
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
+        "error-stack-parser": "^2.0.6",
         "eventemitter3": "^3.0.0",
         "fbjs": "^1.0.0",
         "fs-extra": "^1.0.0",
         "graceful-fs": "^4.1.3",
         "image-size": "^0.6.0",
         "invariant": "^2.2.4",
-        "jest-haste-map": "^24.7.1",
-        "jest-worker": "^24.6.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-worker": "^24.9.0",
         "json-stable-stringify": "^1.0.1",
         "lodash.throttle": "^4.1.1",
         "merge-stream": "^1.0.1",
-        "metro-babel-register": "0.58.0",
-        "metro-babel-transformer": "0.58.0",
-        "metro-cache": "0.58.0",
-        "metro-config": "0.58.0",
-        "metro-core": "0.58.0",
-        "metro-inspector-proxy": "0.58.0",
-        "metro-minify-uglify": "0.58.0",
-        "metro-react-native-babel-preset": "0.58.0",
-        "metro-resolver": "0.58.0",
-        "metro-source-map": "0.58.0",
-        "metro-symbolicate": "0.58.0",
+        "metro-babel-register": "0.59.0",
+        "metro-babel-transformer": "0.59.0",
+        "metro-cache": "0.59.0",
+        "metro-config": "0.59.0",
+        "metro-core": "0.59.0",
+        "metro-inspector-proxy": "0.59.0",
+        "metro-minify-uglify": "0.59.0",
+        "metro-react-native-babel-preset": "0.59.0",
+        "metro-resolver": "0.59.0",
+        "metro-source-map": "0.59.0",
+        "metro-symbolicate": "0.59.0",
         "mime-types": "2.1.11",
         "mkdirp": "^0.5.1",
         "node-fetch": "^2.2.0",
@@ -62711,7 +62616,6 @@
         "temp": "0.8.3",
         "throat": "^4.1.0",
         "wordwrap": "^1.0.0",
-        "write-file-atomic": "^1.2.0",
         "ws": "^1.1.5",
         "xpipe": "^1.0.5",
         "yargs": "^14.2.0"
@@ -62746,11 +62650,6 @@
               }
             }
           }
-        },
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "debug": {
           "version": "2.6.9",
@@ -62798,81 +62697,6 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
-          }
-        },
-        "metro-babel-register": {
-          "version": "0.58.0",
-          "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.58.0.tgz",
-          "integrity": "sha512-P5+G3ufhSYL6cA3a7xkbSJzzFBvtivj/PhWvGXFXnuFssDlMAX1CTktff+0gpka5Cd6B6QLt0UAMWulUAAE4Eg==",
-          "requires": {
-            "@babel/core": "^7.0.0",
-            "@babel/plugin-proposal-class-properties": "^7.0.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-            "@babel/plugin-transform-async-to-generator": "^7.0.0",
-            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-            "@babel/register": "^7.0.0",
-            "core-js": "^2.2.2",
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "metro-react-native-babel-preset": {
-          "version": "0.58.0",
-          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
-          "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
-          "requires": {
-            "@babel/plugin-proposal-class-properties": "^7.0.0",
-            "@babel/plugin-proposal-export-default-from": "^7.0.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-            "@babel/plugin-syntax-export-default-from": "^7.0.0",
-            "@babel/plugin-syntax-flow": "^7.2.0",
-            "@babel/plugin-transform-arrow-functions": "^7.0.0",
-            "@babel/plugin-transform-block-scoping": "^7.0.0",
-            "@babel/plugin-transform-classes": "^7.0.0",
-            "@babel/plugin-transform-computed-properties": "^7.0.0",
-            "@babel/plugin-transform-destructuring": "^7.0.0",
-            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-            "@babel/plugin-transform-for-of": "^7.0.0",
-            "@babel/plugin-transform-function-name": "^7.0.0",
-            "@babel/plugin-transform-literals": "^7.0.0",
-            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-            "@babel/plugin-transform-object-assign": "^7.0.0",
-            "@babel/plugin-transform-parameters": "^7.0.0",
-            "@babel/plugin-transform-react-display-name": "^7.0.0",
-            "@babel/plugin-transform-react-jsx": "^7.0.0",
-            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-            "@babel/plugin-transform-regenerator": "^7.0.0",
-            "@babel/plugin-transform-runtime": "^7.0.0",
-            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-            "@babel/plugin-transform-spread": "^7.0.0",
-            "@babel/plugin-transform-sticky-regex": "^7.0.0",
-            "@babel/plugin-transform-template-literals": "^7.0.0",
-            "@babel/plugin-transform-typescript": "^7.5.0",
-            "@babel/plugin-transform-unicode-regex": "^7.0.0",
-            "@babel/template": "^7.0.0",
-            "react-refresh": "^0.4.0"
-          }
-        },
-        "metro-source-map": {
-          "version": "0.58.0",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-          "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-          "requires": {
-            "@babel/traverse": "^7.0.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.58.0",
-            "ob1": "0.58.0",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
           }
         },
         "mime-db": {
@@ -62972,16 +62796,6 @@
             }
           }
         },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
-        },
         "yargs": {
           "version": "14.2.3",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
@@ -63027,118 +62841,55 @@
       }
     },
     "metro-babel-transformer": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.58.0.tgz",
-      "integrity": "sha512-yBX3BkRhw2TCNPhe+pmLSgsAEA3huMvnX08UwjFqSXXI1aiqzRQobn92uKd1U5MM1Vx8EtXVomlJb95ZHNAv6A==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.59.0.tgz",
+      "integrity": "sha512-fdZJl8rs54GVFXokxRdD7ZrQ1TJjxWzOi/xSP25VR3E8tbm3nBZqS+/ylu643qSr/IueABR+jrlqAyACwGEf6w==",
       "requires": {
         "@babel/core": "^7.0.0",
-        "metro-source-map": "0.58.0"
-      },
-      "dependencies": {
-        "metro-source-map": {
-          "version": "0.58.0",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-          "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-          "requires": {
-            "@babel/traverse": "^7.0.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.58.0",
-            "ob1": "0.58.0",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
-          }
-        }
+        "metro-source-map": "0.59.0"
       }
     },
     "metro-cache": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.58.0.tgz",
-      "integrity": "sha512-jjW9zCTKxhgKcVkyQ6LHyna9Zdf4TK/45vvT1fPyyTk1RY82ZYjU1qs+84ycKEd08Ka4YcK9xcUew9SIDJYI8Q==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.59.0.tgz",
+      "integrity": "sha512-ryWNkSnpyADfRpHGb8BRhQ3+k8bdT/bsxMH2O0ntlZYZ188d8nnYWmxbRvFmEzToJxe/ol4uDw0tJFAaQsN8KA==",
       "requires": {
-        "jest-serializer": "^24.4.0",
-        "metro-core": "0.58.0",
+        "jest-serializer": "^24.9.0",
+        "metro-core": "0.59.0",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4"
       }
     },
     "metro-config": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.58.0.tgz",
-      "integrity": "sha512-4vgBliXwL56vjUlYplvGMVSNrJJpkHuLcD+O20trV3FvPxKg4ZsvuOcNSxqDSMU26FCtIEJ15ojcuCbRL7KY0w==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.59.0.tgz",
+      "integrity": "sha512-MDsknFG9vZ4Nb5VR6OUDmGHaWz6oZg/FtE3up1zVBKPVRTXE1Z+k7zypnPtMXjMh3WHs/Sy4+wU1xnceE/zdnA==",
       "requires": {
         "cosmiconfig": "^5.0.5",
-        "jest-validate": "^24.7.0",
-        "metro": "0.58.0",
-        "metro-cache": "0.58.0",
-        "metro-core": "0.58.0",
-        "pretty-format": "^24.7.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "*",
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "pretty-format": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-          "requires": {
-            "@jest/types": "^24.9.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^3.2.0",
-            "react-is": "^16.8.4"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "jest-validate": "^24.9.0",
+        "metro": "0.59.0",
+        "metro-cache": "0.59.0",
+        "metro-core": "0.59.0"
       }
     },
     "metro-core": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.58.0.tgz",
-      "integrity": "sha512-RzXUjGFmCLOyzUqcKDvr91AldGtIOxnzNZrWUIiG8uC3kerVLo0mQp4YH3+XVm6fMNiLMg6iER7HLqD+MbpUjQ==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.59.0.tgz",
+      "integrity": "sha512-kb5LKvV5r2pqMEzGyTid8ai2mIjW13NMduQ8oBmfha7/EPTATcTQ//s+bkhAs1toQD8vqVvjAb0cPNjWQEmcmQ==",
       "requires": {
-        "jest-haste-map": "^24.7.1",
+        "jest-haste-map": "^24.9.0",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.58.0",
+        "metro-resolver": "0.59.0",
         "wordwrap": "^1.0.0"
       }
     },
     "metro-inspector-proxy": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.58.0.tgz",
-      "integrity": "sha512-oFqTyNTJdCdvcw1Ha6SKE7ITbSaoTbO4xpYownIoJR+WZ0ZfxbWpp225JkHuBJm9UcBAnG9c0CME924m3uBbaw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.59.0.tgz",
+      "integrity": "sha512-hPeAuQcofTOH0F+2GEZqWkvkVY1/skezSSlMocDQDaqds+Kw6JgdA7FlZXxnKmQ/jYrWUzff/pl8SUCDwuYthQ==",
       "requires": {
         "connect": "^3.6.5",
         "debug": "^2.2.0",
-        "rxjs": "^5.4.3",
         "ws": "^1.1.5",
         "yargs": "^14.2.0"
       },
@@ -63259,9 +63010,9 @@
       }
     },
     "metro-minify-uglify": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.58.0.tgz",
-      "integrity": "sha512-vRHsA7bCi7eCn3LXLm20EfY2NoWDyYOnmWaq/N8LB0OxL2L5DXRqMYAQK+prWGJ5S1yvVnDuuNVP+peQ9851TA==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.59.0.tgz",
+      "integrity": "sha512-7IzVgCVWZMymgZ/quieg/9v5EQ8QmZWAgDc86Zp9j0Vy6tQTjUn6jlU+YAKW3mfMEjMr6iIUzCD8YklX78tFAw==",
       "requires": {
         "uglify-es": "^3.1.9"
       }
@@ -63321,23 +63072,12 @@
         "metro-babel-transformer": "0.59.0",
         "metro-react-native-babel-preset": "0.59.0",
         "metro-source-map": "0.59.0"
-      },
-      "dependencies": {
-        "metro-babel-transformer": {
-          "version": "0.59.0",
-          "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.59.0.tgz",
-          "integrity": "sha512-fdZJl8rs54GVFXokxRdD7ZrQ1TJjxWzOi/xSP25VR3E8tbm3nBZqS+/ylu643qSr/IueABR+jrlqAyACwGEf6w==",
-          "requires": {
-            "@babel/core": "^7.0.0",
-            "metro-source-map": "0.59.0"
-          }
-        }
       }
     },
     "metro-resolver": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.58.0.tgz",
-      "integrity": "sha512-XFbAKvCHN2iWqKeiRARzEXn69eTDdJVJC7lu16S4dPQJ+Dy82dZBr5Es12iN+NmbJuFgrAuIHbpWrdnA9tOf6Q==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.59.0.tgz",
+      "integrity": "sha512-lbgiumnwoVosffEI96z0FGuq1ejTorHAj3QYUPmp5dFMfitRxLP7Wm/WP9l4ZZjIptxTExsJwuEff1SLRCPD9w==",
       "requires": {
         "absolute-path": "^0.0.0"
       }
@@ -63356,18 +63096,6 @@
         "vlq": "^1.0.0"
       },
       "dependencies": {
-        "metro-symbolicate": {
-          "version": "0.59.0",
-          "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.59.0.tgz",
-          "integrity": "sha512-asLaF2A7rndrToGFIknL13aiohwPJ95RKHf0NM3hP/nipiLDoMzXT6ZnQvBqDxkUKyP+51AI75DMtb+Wcyw4Bw==",
-          "requires": {
-            "invariant": "^2.2.4",
-            "metro-source-map": "0.59.0",
-            "source-map": "^0.5.6",
-            "through2": "^2.0.1",
-            "vlq": "^1.0.0"
-          }
-        },
         "ob1": {
           "version": "0.59.0",
           "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.59.0.tgz",
@@ -63376,31 +63104,15 @@
       }
     },
     "metro-symbolicate": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.58.0.tgz",
-      "integrity": "sha512-uIVxUQC1E26qOMj13dKROhwAa2FmZk5eR0NcBqej/aXmQhpr8LjJg2sondkoLKUp827Tf/Fm9+pS4icb5XiqCw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.59.0.tgz",
+      "integrity": "sha512-asLaF2A7rndrToGFIknL13aiohwPJ95RKHf0NM3hP/nipiLDoMzXT6ZnQvBqDxkUKyP+51AI75DMtb+Wcyw4Bw==",
       "requires": {
         "invariant": "^2.2.4",
-        "metro-source-map": "0.58.0",
+        "metro-source-map": "0.59.0",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
         "vlq": "^1.0.0"
-      },
-      "dependencies": {
-        "metro-source-map": {
-          "version": "0.58.0",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-          "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-          "requires": {
-            "@babel/traverse": "^7.0.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.58.0",
-            "ob1": "0.58.0",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
-          }
-        }
       }
     },
     "microevent.ts": {
@@ -64063,11 +63775,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
-    },
-    "ob1": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.58.0.tgz",
-      "integrity": "sha512-uZP44cbowAfHafP1k4skpWItk5iHCoRevMfrnUvYCfyNNPPJd3rfDCyj0exklWi2gDXvjlj2ObsfiqP/bs/J7Q=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -64854,13 +64561,20 @@
       }
     },
     "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "requires": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "xmldom": "^0.5.0"
+      },
+      "dependencies": {
+        "xmldom": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+          "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+        }
       }
     },
     "plugin-error": {
@@ -65989,9 +65703,9 @@
       }
     },
     "react-dev-utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.1.tgz",
-      "integrity": "sha512-rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
+      "integrity": "sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.10.4",
@@ -66007,13 +65721,13 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "7.0.9",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "^6.0.8",
+        "react-error-overlay": "^6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
@@ -66261,9 +65975,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
-      "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "react-fast-compare": {
@@ -66363,98 +66077,6 @@
         "whatwg-fetch": "^3.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
-        "@react-native-community/cli": {
-          "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.13.1.tgz",
-          "integrity": "sha512-+/TeRVToADpQPSprsPkwi9KY8x64YcuJpjzMBVISwWP+aWzsIDuWJmyMXTADlCg2EBMJqJR7bn1W/IkfzVRCWA==",
-          "requires": {
-            "@hapi/joi": "^15.0.3",
-            "@react-native-community/cli-debugger-ui": "^4.13.1",
-            "@react-native-community/cli-hermes": "^4.13.0",
-            "@react-native-community/cli-server-api": "^4.13.1",
-            "@react-native-community/cli-tools": "^4.13.0",
-            "@react-native-community/cli-types": "^4.10.1",
-            "chalk": "^3.0.0",
-            "command-exists": "^1.2.8",
-            "commander": "^2.19.0",
-            "cosmiconfig": "^5.1.0",
-            "deepmerge": "^3.2.0",
-            "envinfo": "^7.7.2",
-            "execa": "^1.0.0",
-            "find-up": "^4.1.0",
-            "fs-extra": "^8.1.0",
-            "glob": "^7.1.3",
-            "graceful-fs": "^4.1.3",
-            "inquirer": "^3.0.6",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.15",
-            "metro": "^0.58.0",
-            "metro-config": "^0.58.0",
-            "metro-core": "^0.58.0",
-            "metro-react-native-babel-transformer": "^0.58.0",
-            "metro-resolver": "^0.58.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-stream-zip": "^1.9.1",
-            "ora": "^3.4.0",
-            "pretty-format": "^25.2.0",
-            "semver": "^6.3.0",
-            "serve-static": "^1.13.1",
-            "strip-ansi": "^5.2.0",
-            "sudo-prompt": "^9.0.0",
-            "wcwidth": "^1.0.1"
-          },
-          "dependencies": {
-            "metro-react-native-babel-transformer": {
-              "version": "0.58.0",
-              "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz",
-              "integrity": "sha512-3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==",
-              "requires": {
-                "@babel/core": "^7.0.0",
-                "babel-preset-fbjs": "^3.3.0",
-                "metro-babel-transformer": "0.58.0",
-                "metro-react-native-babel-preset": "0.58.0",
-                "metro-source-map": "0.58.0"
-              }
-            },
-            "metro-source-map": {
-              "version": "0.58.0",
-              "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
-              "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
-              "requires": {
-                "@babel/traverse": "^7.0.0",
-                "@babel/types": "^7.0.0",
-                "invariant": "^2.2.4",
-                "metro-symbolicate": "0.58.0",
-                "ob1": "0.58.0",
-                "source-map": "^0.5.6",
-                "vlq": "^1.0.0"
-              }
-            },
-            "pretty-format": {
-              "version": "25.5.0",
-              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-              "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-              "requires": {
-                "@jest/types": "^25.5.0",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
-                "react-is": "^16.12.0"
-              }
-            }
-          }
-        },
         "@types/istanbul-reports": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
@@ -66463,146 +66085,6 @@
             "@types/istanbul-lib-coverage": "*",
             "@types/istanbul-lib-report": "*"
           }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "metro-react-native-babel-preset": {
-          "version": "0.58.0",
-          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
-          "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
-          "requires": {
-            "@babel/plugin-proposal-class-properties": "^7.0.0",
-            "@babel/plugin-proposal-export-default-from": "^7.0.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-            "@babel/plugin-syntax-export-default-from": "^7.0.0",
-            "@babel/plugin-syntax-flow": "^7.2.0",
-            "@babel/plugin-transform-arrow-functions": "^7.0.0",
-            "@babel/plugin-transform-block-scoping": "^7.0.0",
-            "@babel/plugin-transform-classes": "^7.0.0",
-            "@babel/plugin-transform-computed-properties": "^7.0.0",
-            "@babel/plugin-transform-destructuring": "^7.0.0",
-            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-            "@babel/plugin-transform-for-of": "^7.0.0",
-            "@babel/plugin-transform-function-name": "^7.0.0",
-            "@babel/plugin-transform-literals": "^7.0.0",
-            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-            "@babel/plugin-transform-object-assign": "^7.0.0",
-            "@babel/plugin-transform-parameters": "^7.0.0",
-            "@babel/plugin-transform-react-display-name": "^7.0.0",
-            "@babel/plugin-transform-react-jsx": "^7.0.0",
-            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-            "@babel/plugin-transform-regenerator": "^7.0.0",
-            "@babel/plugin-transform-runtime": "^7.0.0",
-            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-            "@babel/plugin-transform-spread": "^7.0.0",
-            "@babel/plugin-transform-sticky-regex": "^7.0.0",
-            "@babel/plugin-transform-template-literals": "^7.0.0",
-            "@babel/plugin-transform-typescript": "^7.5.0",
-            "@babel/plugin-transform-unicode-regex": "^7.0.0",
-            "@babel/template": "^7.0.0",
-            "react-refresh": "^0.4.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "pretty-format": {
           "version": "24.9.0",
@@ -66673,19 +66155,6 @@
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -67449,14 +66918,6 @@
         "rx-lite": "*"
       }
     },
-    "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -67844,11 +67305,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-    },
     "slugify": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.0.tgz",
@@ -68143,8 +67599,7 @@
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-      "dev": true
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "stacktrace-parser": {
       "version": "0.1.10",
@@ -68562,11 +68017,6 @@
         "lower-case": "^1.1.1",
         "upper-case": "^1.1.1"
       }
-    },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "symbol-tree": {
       "version": "3.2.4",


### PR DESCRIPTION
## Description

For now we'll need to use legacy-peer-deps because too many packages have too restrictive peerDependencies.


### 📋 Acceptance Criteria

> Checked off by the PR **Assignee(s)**

- [x] `npm i` works now


### 👩‍🔬 Test Instructions

1. `npm i` works
2. `npm run test:ci` works

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

### Additional

> Delete if unneeded

- [ ] Code has been tested and confirmed locally

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup